### PR TITLE
feat: Add support for celery beat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,3 @@
-# [Unreleased]
-
-### Features
-
-* Added support for celery beat healthcheck
-
 # [0.2.0](https://github.com/iloveitaly/celery-healthcheck/compare/v0.1.2...v0.2.0) (2025-09-21)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# [Unreleased]
+
+### Features
+
+* Added support for celery beat healthcheck
+
 # [0.2.0](https://github.com/iloveitaly/celery-healthcheck/compare/v0.1.2...v0.2.0) (2025-09-21)
 
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Reports whether beat has ticked recently.
 - `healthcheck_beat_max_tick_age`: Explicit override for the staleness threshold, in seconds. If unset, it's derived from the scheduler's own `max_interval` instead (see below).
 - `healthcheck_beat_tick_age_multiplier`: Multiplier applied to the scheduler's `max_interval` when deriving the default threshold (default: 2.0)
 
-> [!NOTE]
+> [!WARNING]
 > `tick()` sleeps up to the scheduler's `max_interval` between calls when nothing is due — stock Celery defaults this to 300 seconds, while `django-celery-beat` and similar backends are typically much shorter. Setting `healthcheck_beat_max_tick_age` below your scheduler's `max_interval` will cause false-positive failures on a healthy beat process. The default (`max_interval * healthcheck_beat_tick_age_multiplier + 10s` grace period) is derived automatically per-scheduler so this shouldn't need tuning in most setups.
 
 ## Azure Configuration

--- a/README.md
+++ b/README.md
@@ -71,6 +71,50 @@ The health check app can be configured via the main celery app it is registered 
 - `healthcheck_port`: The port on which the health check server will listen (default: 9000)
 - `healthcheck_ping_timeout`: The timeout for the ping command to the worker (default: 2.0 seconds)
 
+## Beat Health Check
+
+`celery_healthcheck.register(app)` also wires up a liveness probe for `celery beat`. No changes to how you start beat are required — no custom `--scheduler` flag, no scheduler subclass. It works by hooking Celery's `beat_init` signal and patching the `tick()` method on whichever scheduler instance beat actually constructs, so it works identically with the stock scheduler, [django-celery-beat](https://github.com/celery/django-celery-beat), [redbeat](https://github.com/sibson/redbeat), or any custom scheduler.
+
+```python
+from celery import Celery
+import celery_healthcheck
+
+app = Celery('myapp')
+app.config_from_object('myapp.celeryconfig')
+
+celery_healthcheck.register(app)
+```
+
+```sh
+celery -A myapp beat -l info
+```
+
+### Why a tick heartbeat instead of a pidfile check
+
+A common approach is checking beat's `--pidfile` for freshness, but Celery only writes that file once at startup as an "already running" lock — it is never touched again, so a staleness check on it can't detect beat hanging or deadlocking after startup, which is the actual failure mode a liveness probe needs to catch. This library instead records a timestamp every time the scheduler's `tick()` method actually runs, so the healthcheck reflects whether beat is still actively scheduling tasks.
+
+### GET / (Beat)
+
+Reports whether beat has ticked recently.
+
+**Response:**
+
+```json
+{
+  "status": "ok",           // or "error"
+  "last_tick_age": 4.2,     // seconds since the last tick
+  "max_tick_age": 610.0     // staleness threshold currently in effect
+}
+```
+
+### Beat Configuration
+
+- `healthcheck_beat_port`: The port on which the beat health check server will listen (default: 9001 — distinct from the worker's 9000, so an embedded `celery worker -B` process can run both without a conflict)
+- `healthcheck_beat_max_tick_age`: Explicit override for the staleness threshold, in seconds. If unset, it's derived from the scheduler's own `max_interval` instead (see below).
+- `healthcheck_beat_tick_age_multiplier`: Multiplier applied to the scheduler's `max_interval` when deriving the default threshold (default: 2.0)
+
+**Important:** `tick()` legitimately sleeps up to the scheduler's `max_interval` between calls when nothing is due — stock Celery defaults this to 300 seconds, while `django-celery-beat` and similar backends are typically much shorter. Setting `healthcheck_beat_max_tick_age` below your scheduler's `max_interval` will cause false-positive failures on a healthy beat process. The default (`max_interval * healthcheck_beat_tick_age_multiplier + 10s` grace period) is derived automatically per-scheduler so this shouldn't need tuning in most setups.
+
 ## Azure Configuration
 
 When configuring Azure health probes:

--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ The health check app can be configured via the main celery app it is registered 
 
 ## Beat Health Check
 
-`celery_healthcheck.register(app)` also wires up a liveness probe for `celery beat`. No changes to how you start beat are required — no custom `--scheduler` flag, no scheduler subclass. It works by hooking Celery's `beat_init` signal and patching the `tick()` method on whichever scheduler instance beat actually constructs, so it works identically with the stock scheduler, [django-celery-beat](https://github.com/celery/django-celery-beat), [redbeat](https://github.com/sibson/redbeat), or any custom scheduler.
+`celery-healthcheck` also supports adding a liveness probe for `celery beat`.
+
+It works by hooking Celery's `beat_init` signal and patching the `tick()` method on whichever scheduler instance beat actually constructs, so it works identically with the stock scheduler, [django-celery-beat](https://github.com/celery/django-celery-beat), [redbeat](https://github.com/sibson/redbeat), or any custom scheduler.
+
+This method ensures that the liveness probe reflects whether beat is still actively scheduling tasks.
 
 ```python
 from celery import Celery
@@ -88,10 +92,6 @@ celery_healthcheck.register(app)
 ```sh
 celery -A myapp beat -l info
 ```
-
-### Why a tick heartbeat instead of a pidfile check
-
-A common approach is checking beat's `--pidfile` for freshness, but Celery only writes that file once at startup as an "already running" lock — it is never touched again, so a staleness check on it can't detect beat hanging or deadlocking after startup, which is the actual failure mode a liveness probe needs to catch. This library instead records a timestamp every time the scheduler's `tick()` method actually runs, so the healthcheck reflects whether beat is still actively scheduling tasks.
 
 ### GET / (Beat)
 
@@ -109,11 +109,12 @@ Reports whether beat has ticked recently.
 
 ### Beat Configuration
 
-- `healthcheck_beat_port`: The port on which the beat health check server will listen (default: 9001 — distinct from the worker's 9000, so an embedded `celery worker -B` process can run both without a conflict)
+- `healthcheck_beat_port`: The port on which the beat health check server will listen (default: 9001)
 - `healthcheck_beat_max_tick_age`: Explicit override for the staleness threshold, in seconds. If unset, it's derived from the scheduler's own `max_interval` instead (see below).
 - `healthcheck_beat_tick_age_multiplier`: Multiplier applied to the scheduler's `max_interval` when deriving the default threshold (default: 2.0)
 
-**Important:** `tick()` legitimately sleeps up to the scheduler's `max_interval` between calls when nothing is due — stock Celery defaults this to 300 seconds, while `django-celery-beat` and similar backends are typically much shorter. Setting `healthcheck_beat_max_tick_age` below your scheduler's `max_interval` will cause false-positive failures on a healthy beat process. The default (`max_interval * healthcheck_beat_tick_age_multiplier + 10s` grace period) is derived automatically per-scheduler so this shouldn't need tuning in most setups.
+> [!NOTE]
+> `tick()` sleeps up to the scheduler's `max_interval` between calls when nothing is due — stock Celery defaults this to 300 seconds, while `django-celery-beat` and similar backends are typically much shorter. Setting `healthcheck_beat_max_tick_age` below your scheduler's `max_interval` will cause false-positive failures on a healthy beat process. The default (`max_interval * healthcheck_beat_tick_age_multiplier + 10s` grace period) is derived automatically per-scheduler so this shouldn't need tuning in most setups.
 
 ## Azure Configuration
 

--- a/celery_healthcheck/__init__.py
+++ b/celery_healthcheck/__init__.py
@@ -1,5 +1,7 @@
+from celery_healthcheck.beat import register_beat
 from celery_healthcheck.server import HealthCheckServer
 
 
 def register(celery_app):
     celery_app.steps["worker"].add(HealthCheckServer)
+    register_beat(celery_app)

--- a/celery_healthcheck/beat.py
+++ b/celery_healthcheck/beat.py
@@ -43,14 +43,12 @@ def _get_max_tick_age():
 
 
 def _resolve_max_tick_age(conf, scheduler):
-    """Derive the staleness threshold from the scheduler's own max_interval.
+    """Determine the staleness threshold from the scheduler's own max_interval.
 
-    tick() legitimately sleeps up to max_interval between calls when nothing
+    tick() sleeps up to max_interval between calls when nothing
     is due, so the threshold must be comfortably larger than that or a
-    healthy beat process will fail the probe. max_interval varies widely by
-    scheduler backend (e.g. stock Celery defaults to 300s, while
-    django-celery-beat / redbeat are typically much shorter), so this is
-    derived rather than hardcoded.
+    It is necessary to calculate the max_interval as it can vary
+    depending on the scheduler.
     """
     explicit = getattr(conf, "healthcheck_beat_max_tick_age", None)
     if explicit:

--- a/celery_healthcheck/beat.py
+++ b/celery_healthcheck/beat.py
@@ -1,0 +1,164 @@
+import logging
+import threading
+import time
+
+import uvicorn
+from celery.signals import beat_init
+from fastapi import FastAPI, status
+from fastapi.responses import JSONResponse
+
+app = FastAPI()
+logger = logging.getLogger("celery.ext.healthcheck.beat")
+
+HEALTHCHECK_BEAT_DEFAULT_PORT = 9001
+HEALTHCHECK_BEAT_DEFAULT_MAX_INTERVAL = 300.0
+HEALTHCHECK_BEAT_DEFAULT_TICK_AGE_MULTIPLIER = 2.0
+HEALTHCHECK_BEAT_TICK_AGE_GRACE = 10.0
+
+_lock = threading.Lock()
+_last_tick_time = None
+_max_tick_age = None
+
+
+def _touch_tick():
+    global _last_tick_time
+    with _lock:
+        _last_tick_time = time.time()
+
+
+def _get_last_tick():
+    with _lock:
+        return _last_tick_time
+
+
+def _set_max_tick_age(value):
+    global _max_tick_age
+    with _lock:
+        _max_tick_age = value
+
+
+def _get_max_tick_age():
+    with _lock:
+        return _max_tick_age
+
+
+def _resolve_max_tick_age(conf, scheduler):
+    """Derive the staleness threshold from the scheduler's own max_interval.
+
+    tick() legitimately sleeps up to max_interval between calls when nothing
+    is due, so the threshold must be comfortably larger than that or a
+    healthy beat process will fail the probe. max_interval varies widely by
+    scheduler backend (e.g. stock Celery defaults to 300s, while
+    django-celery-beat / redbeat are typically much shorter), so this is
+    derived rather than hardcoded.
+    """
+    explicit = getattr(conf, "healthcheck_beat_max_tick_age", None)
+    if explicit:
+        return float(explicit)
+
+    base = (
+        getattr(scheduler, "max_interval", None)
+        or HEALTHCHECK_BEAT_DEFAULT_MAX_INTERVAL
+    )
+    multiplier = float(
+        getattr(
+            conf,
+            "healthcheck_beat_tick_age_multiplier",
+            HEALTHCHECK_BEAT_DEFAULT_TICK_AGE_MULTIPLIER,
+        )
+    )
+    return (base * multiplier) + HEALTHCHECK_BEAT_TICK_AGE_GRACE
+
+
+@app.get("/")
+async def beat_ping():
+    last = _get_last_tick()
+    max_tick_age = _get_max_tick_age() or HEALTHCHECK_BEAT_DEFAULT_MAX_INTERVAL
+
+    if last is None:
+        return JSONResponse(
+            content={"status": "error", "detail": "beat has not ticked yet"},
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    age = time.time() - last
+
+    if age > max_tick_age:
+        return JSONResponse(
+            content={
+                "status": "error",
+                "detail": f"last tick {age:.1f}s ago exceeds max_tick_age {max_tick_age:.1f}s",
+                "last_tick_age": age,
+                "max_tick_age": max_tick_age,
+            },
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        )
+
+    return JSONResponse(
+        content={"status": "ok", "last_tick_age": age, "max_tick_age": max_tick_age},
+        status_code=status.HTTP_200_OK,
+    )
+
+
+def _patch_scheduler_tick(scheduler):
+    """Wrap scheduler.tick() to record a heartbeat, without altering its return value.
+
+    tick()'s return value is the sleep interval Celery's Service loop uses to
+    schedule its next wakeup, so it must be passed through unchanged.
+    """
+    if getattr(scheduler, "_healthcheck_patched", False):
+        return
+
+    original_tick = scheduler.tick
+
+    def tick(*args, **kwargs):
+        _touch_tick()
+        return original_tick(*args, **kwargs)
+
+    scheduler.tick = tick
+    scheduler._healthcheck_patched = True
+
+
+def _start_server(port):
+    def run_server():
+        uvicorn.run(app, host="0.0.0.0", port=port)
+
+    thread = threading.Thread(target=run_server, daemon=True)
+    thread.start()
+
+    logger.info(f"Beat health check server started on port {port}")
+
+
+def _make_beat_init_handler(celery_app):
+    def _on_beat_init(sender=None, **kwargs):
+        scheduler = getattr(sender, "scheduler", None)
+        if scheduler is None:
+            logger.warning(
+                "celery-healthcheck: could not find scheduler on beat_init sender, "
+                "beat healthcheck will not be started"
+            )
+            return
+
+        conf = celery_app.conf
+        port = int(
+            getattr(conf, "healthcheck_beat_port", HEALTHCHECK_BEAT_DEFAULT_PORT)
+        )
+
+        _patch_scheduler_tick(scheduler)
+        _set_max_tick_age(_resolve_max_tick_age(conf, scheduler))
+        _start_server(port)
+
+    return _on_beat_init
+
+
+def register_beat(celery_app):
+    """Register a beat_init handler that installs a tick heartbeat and healthcheck server.
+
+    This works with any scheduler (stock Celery, django-celery-beat, redbeat,
+    or custom schedulers) since it patches the live scheduler instance that
+    beat_init exposes, rather than requiring a scheduler subclass or a
+    --scheduler CLI flag change.
+    """
+    handler = _make_beat_init_handler(celery_app)
+    beat_init.connect(handler, weak=False)
+    return handler

--- a/tests/test_beat.py
+++ b/tests/test_beat.py
@@ -1,0 +1,187 @@
+"""Test the beat health check."""
+
+import time
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from celery_healthcheck import beat
+
+
+@pytest.fixture(autouse=True)
+def reset_beat_state():
+    """Reset module-level tick state so tests don't leak into each other."""
+    with beat._lock:
+        beat._last_tick_time = None
+        beat._max_tick_age = None
+    yield
+    with beat._lock:
+        beat._last_tick_time = None
+        beat._max_tick_age = None
+
+
+@pytest.fixture
+def test_client():
+    """TestClient for the module-level beat FastAPI app."""
+    return TestClient(beat.app)
+
+
+class FakeScheduler:
+    """A bare stand-in for a real Celery scheduler instance.
+
+    Deliberately not a Mock: Mock auto-creates attributes on access, which
+    would make `getattr(scheduler, "_healthcheck_patched", False)` always
+    truthy and defeat the double-patch guard under test.
+    """
+
+    def __init__(self, max_interval=300):
+        self.max_interval = max_interval
+
+    def tick(self, *args, **kwargs):
+        return "original-return-value"
+
+
+@pytest.fixture
+def mock_scheduler():
+    return FakeScheduler()
+
+
+@pytest.fixture
+def mock_celery_app():
+    app = Mock()
+    app.conf = object()  # getattr falls through to defaults, like test_server.py
+    return app
+
+
+def test_beat_ping_never_ticked(test_client):
+    response = test_client.get("/")
+
+    assert response.status_code == 503
+    assert response.json()["status"] == "error"
+
+
+def test_beat_ping_healthy(test_client):
+    beat._touch_tick()
+    beat._set_max_tick_age(60.0)
+
+    response = test_client.get("/")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "ok"
+    assert body["last_tick_age"] < 1.0
+    assert body["max_tick_age"] == 60.0
+
+
+def test_beat_ping_stale_tick(test_client):
+    with beat._lock:
+        beat._last_tick_time = time.time() - 100
+    beat._set_max_tick_age(10.0)
+
+    response = test_client.get("/")
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "error"
+    assert body["last_tick_age"] > 10.0
+
+
+def test_patch_scheduler_tick_preserves_return_value_and_touches(mock_scheduler):
+    assert beat._get_last_tick() is None
+
+    result = mock_scheduler.tick()
+    assert result == "original-return-value"
+
+    beat._patch_scheduler_tick(mock_scheduler)
+
+    result = mock_scheduler.tick()
+
+    assert result == "original-return-value"
+    assert beat._get_last_tick() is not None
+
+
+def test_patch_scheduler_tick_does_not_double_wrap(mock_scheduler):
+    call_count = {"n": 0}
+    original_tick = mock_scheduler.tick
+
+    def counting_tick(*args, **kwargs):
+        call_count["n"] += 1
+        return original_tick(*args, **kwargs)
+
+    mock_scheduler.tick = counting_tick
+
+    beat._patch_scheduler_tick(mock_scheduler)
+    beat._patch_scheduler_tick(mock_scheduler)  # second call should be a no-op
+
+    mock_scheduler.tick()
+
+    assert call_count["n"] == 1
+
+
+def test_resolve_max_tick_age_stock_default(mock_scheduler):
+    conf = object()
+    mock_scheduler.max_interval = 300
+
+    assert beat._resolve_max_tick_age(conf, mock_scheduler) == 300 * 2.0 + 10.0
+
+
+def test_resolve_max_tick_age_short_interval_scheduler(mock_scheduler):
+    conf = object()
+    mock_scheduler.max_interval = 5
+
+    assert beat._resolve_max_tick_age(conf, mock_scheduler) == 5 * 2.0 + 10.0
+
+
+def test_resolve_max_tick_age_explicit_override_wins(mock_scheduler):
+    conf = SimpleNamespace(healthcheck_beat_max_tick_age=42.0)
+    mock_scheduler.max_interval = 5
+
+    assert beat._resolve_max_tick_age(conf, mock_scheduler) == 42.0
+
+
+def test_resolve_max_tick_age_custom_multiplier(mock_scheduler):
+    conf = SimpleNamespace(healthcheck_beat_tick_age_multiplier=3.0)
+    mock_scheduler.max_interval = 10
+
+    assert beat._resolve_max_tick_age(conf, mock_scheduler) == 10 * 3.0 + 10.0
+
+
+def test_beat_init_handler_starts_server(mock_celery_app, mock_scheduler):
+    handler = beat._make_beat_init_handler(mock_celery_app)
+    sender = SimpleNamespace(scheduler=mock_scheduler)
+
+    with patch("celery_healthcheck.beat.uvicorn.run") as mock_run:
+        handler(sender=sender)
+
+    mock_run.assert_called_once()
+    assert mock_scheduler._healthcheck_patched is True
+    assert beat._get_max_tick_age() is not None
+
+
+def test_beat_init_handler_missing_scheduler_does_not_start_server(mock_celery_app):
+    handler = beat._make_beat_init_handler(mock_celery_app)
+    sender = SimpleNamespace()  # no `scheduler` attribute
+
+    with patch("celery_healthcheck.beat.uvicorn.run") as mock_run:
+        handler(sender=sender)
+
+    mock_run.assert_not_called()
+    assert beat._get_max_tick_age() is None
+
+
+def test_register_beat_connects_handler(mock_celery_app, mock_scheduler):
+    handler = beat.register_beat(mock_celery_app)
+    try:
+        # celery's Signal.send() caches receivers per-sender and requires the
+        # sender to be hashable, unlike SimpleNamespace used elsewhere here.
+        sender = Mock()
+        sender.scheduler = mock_scheduler
+
+        with patch("celery_healthcheck.beat.uvicorn.run") as mock_run:
+            beat.beat_init.send(sender=sender)
+
+        mock_run.assert_called_once()
+    finally:
+        beat.beat_init.disconnect(handler)

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,0 +1,28 @@
+"""Test the register function in celery-healthcheck."""
+
+from unittest.mock import Mock, patch
+
+from celery_healthcheck.server import HealthCheckServer
+
+
+def test_register_function():
+    """Test the register function adds HealthCheckServer to celery app steps and wires up beat."""
+    from celery_healthcheck import register
+
+    # Mock celery app
+    mock_celery_app = Mock()
+    mock_celery_app.steps = {"worker": Mock()}
+    mock_celery_app.steps["worker"].add = Mock()
+
+    # Call register function
+    handler = None
+    with patch("celery_healthcheck.beat.beat_init.connect") as mock_connect:
+        register(mock_celery_app)
+        handler = mock_connect.call_args[0][0]
+
+    # Assert HealthCheckServer was added to worker steps
+    mock_celery_app.steps["worker"].add.assert_called_once_with(HealthCheckServer)
+
+    # Assert a beat_init handler was connected (works for any scheduler, no
+    # subclassing or --scheduler flag required)
+    assert callable(handler)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,7 +1,8 @@
 """Test the health check server."""
 
-import pytest
 from unittest.mock import Mock, patch
+
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -118,26 +119,3 @@ def test_health_server_stop_method(health_server, mock_worker):
     """Test that stop method exists and can be called."""
     # Should not raise any exceptions
     health_server.stop(mock_worker)
-
-
-def test_register_function():
-    """Test the register function adds HealthCheckServer to celery app steps and wires up beat."""
-    from celery_healthcheck import register
-
-    # Mock celery app
-    mock_celery_app = Mock()
-    mock_celery_app.steps = {"worker": Mock()}
-    mock_celery_app.steps["worker"].add = Mock()
-
-    # Call register function
-    handler = None
-    with patch("celery_healthcheck.beat.beat_init.connect") as mock_connect:
-        register(mock_celery_app)
-        handler = mock_connect.call_args[0][0]
-
-    # Assert HealthCheckServer was added to worker steps
-    mock_celery_app.steps["worker"].add.assert_called_once_with(HealthCheckServer)
-
-    # Assert a beat_init handler was connected (works for any scheduler, no
-    # subclassing or --scheduler flag required)
-    assert callable(handler)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -121,7 +121,7 @@ def test_health_server_stop_method(health_server, mock_worker):
 
 
 def test_register_function():
-    """Test the register function adds HealthCheckServer to celery app steps."""
+    """Test the register function adds HealthCheckServer to celery app steps and wires up beat."""
     from celery_healthcheck import register
 
     # Mock celery app
@@ -130,7 +130,14 @@ def test_register_function():
     mock_celery_app.steps["worker"].add = Mock()
 
     # Call register function
-    register(mock_celery_app)
+    handler = None
+    with patch("celery_healthcheck.beat.beat_init.connect") as mock_connect:
+        register(mock_celery_app)
+        handler = mock_connect.call_args[0][0]
 
     # Assert HealthCheckServer was added to worker steps
     mock_celery_app.steps["worker"].add.assert_called_once_with(HealthCheckServer)
+
+    # Assert a beat_init handler was connected (works for any scheduler, no
+    # subclassing or --scheduler flag required)
+    assert callable(handler)


### PR DESCRIPTION
Thanks for this library, it has proved useful for us with worker health checks. We ran into a situation where we wanted to have a health check for a celery `beat` process as well so I have gone through and added support.

Please see what you think. Full disclosure in that Claude Code has helped with this but I have given it a full review myself and changed a few bits.

I have tested it "live" and it seems to work well.

## Changes

- Added a health check server for the `celery beat` process.
  - The check works by patching the `tick()` method that `beat` uses to determine whether to schedule a task.
  - Like the server instance, a fastapi server is spun up in a thread using the `beat_init`signal.
  - Upon being called, the server checks for the time since the last `tick()` occurred.
  - A 503 is returned if the time since the last tick is significantly larger than the `max_interval` of the celery config.
- New config variables:
  - `healthcheck_beat_port`: The port on which the beat health check server will listen (default: 9001)
  - `healthcheck_beat_max_tick_age`: Explicit override for the staleness threshold, in seconds. If unset, it's derived from the scheduler's own `max_interval` instead (see below).
  - `healthcheck_beat_tick_age_multiplier`: Multiplier applied to the scheduler's `max_interval` when deriving the default threshold (default: 2.0)
- Register test moved to own file due to including beat setup and not exclusive to `server.py`.